### PR TITLE
Improve asset publishing and refactor README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,148 +54,6 @@ This package is a collection of some other packages with information on:
     - world-flags-sprite, based on [https://github.com/lafeber/world-flags-sprite](https://github.com/lafeber/world-flags-sprite)
     - svg, the flag svg file loaded into the json
   
-## Usage
- 
-The package is based on Laravel Collections, so you basically have access to all methods in Collections, like 
-
-    $all = Countries::all();
-     
-This filter
-
-    Countries::where('name.common', 'Brazil')
-
-Will find Brazil by its common name, which is a 
-
-      #items: array:22 [▼
-        "name" => array:3 [▼
-          "common" => "Brazil"
-          "official" => "Federative Republic of Brazil"
-          "native" => array:1 [▼
-            "por" => array:2 [▼
-              "official" => "República Federativa do Brasil"
-              "common" => "Brasil"
-            ]
-          ]
-        ]
-        
-And, you can go deepeer
-         
-     Countries::where('name.native.por.common', 'Brasil')
-     
-Or search by the country top level domain
-     
-     Countries::where('tld.0', '.ch')
-     
-To get
-
-    "name" => array:3 [▼
-      "common" => "Switzerland"
-      "official" => "Swiss Confederation"
-      "native" => array:4 [▶]
-    ]
-    "tld" => array:1 [▼
-      0 => ".ch"
-    ]
-    
-And use things like pluck
-
-    Countries::where('cca3', 'USA')->first()->states->pluck('name', 'postal')
-
-To get
-
-    "MA" => "Massachusetts"
-    "MN" => "Minnesota"
-    "MT" => "Montana"
-    "ND" => "North Dakota"
-    "HI" => "Hawaii"
-    "ID" => "Idaho"
-    "WA" => "Washington"
-    "AZ" => "Arizona"
-    "CA" => "California"
-    "CO" => "Colorado"
-    "NV" => "Nevada"
-    "NM" => "New Mexico"
-    "OR" => "Oregon"
-    "UT" => "Utah"
-    "WY" => "Wyoming"
-    "AR" => "Arkansas"
-    "IA" => "Iowa"
-    "KS" => "Kansas"
-    "MO" => "Missouri"
-    "NE" => "Nebraska"
-    "OK" => "Oklahoma"
-    "SD" => "South Dakota"
-    "LA" => "Louisiana"
-    "TX" => "Texas"
-    "CT" => "Connecticut"
-    "NH" => "New Hampshire"
-    "RI" => "Rhode Island"
-    "VT" => "Vermont"
-    "AL" => "Alabama"
-    "FL" => "Florida"
-    "GA" => "Georgia"
-    "MS" => "Mississippi"
-    "SC" => "South Carolina"
-    "IL" => "Illinois"
-    "IN" => "Indiana"
-    "KY" => "Kentucky"
-    "NC" => "North Carolina"
-    "OH" => "Ohio"
-    "TN" => "Tennessee"
-    "VA" => "Virginia"
-    "WI" => "Wisconsin"
-    "WV" => "West Virginia"
-    "DE" => "Delaware"
-    "DC" => "District of Columbia"
-    "MD" => "Maryland"
-    "NJ" => "New Jersey"
-    "NY" => "New York"
-    "PA" => "Pennsylvania"
-    "ME" => "Maine"
-    "MI" => "Michigan"
-    "AK" => "Alaska"
-          
-The package uses a modified Collection which allows you to access properties and methods as objects:
-         
-    Countries::where('cca3', 'FRA')
-        ->first()
-        ->borders
-        ->first()
-        ->name
-        ->official
-    
-Should give
-    
-    Principality of Andorra
-         
-Borders hydration is disabled by default, but you can have your borders hydrated easily by calling the hydrate method:
- 
-    Countries::where('name.common', 'United Kingdom')
-        ->hydrate('borders')
-        ->first()
-        ->borders
-        ->reverse()
-        ->first()
-        ->name
-        ->common
-
-Should return 
-
-    Ireland
-
-## Data
-
-This package uses some other open source packages and, until we don't build a better documentation, you can find some more info about data on [mledoze/countries](https://github.com/mledoze/countries/blob/master/README.md) and how to use it on this fantastic [Laravel News article](https://laravel-news.com/countries-and-currencies).
-
-## Cache
-
-Since this data is not supposed to change, calls are automatically cached, but you can changed that.  
-
-## Sample files
-
-- [sample-partial.json](src/data/sample-partial.json): example of a country with no borders hydrated.
-- [sample-full.json](src/data/sample-full.json): example of a fully hydrated country.
-
 ## Requirements
 
 - PHP 7.0+
@@ -205,25 +63,203 @@ Since this data is not supposed to change, calls are automatically cached, but y
 
 Use Composer to install it:
 
-    composer require pragmarx/countries
+```
+composer require pragmarx/countries
+```
 
 ## Installing on Laravel
 
-Add the Service Provider and Facade alias to your `app/config/app.php` (Laravel 4.x) or `config/app.php` (Laravel 5.x):
+Add the Service Provider and Facade alias to your `config/app.php`:
     
-    ```php
-    // config/app.php
+```php
+// config/app.php
 
-    'providers' => [
-        ...
-        PragmaRX\Countries\ServiceProvider::class,
-    ];
+'providers' => [
+    // ...
+    PragmaRX\Countries\ServiceProvider::class,
+];
 
-    'aliases' => [
-        ...
-        'Countries'=> PragmaRX\Countries\Facade::class,
-    ];
-    ```
+'aliases' => [
+    // ...
+    'Countries'=> PragmaRX\Countries\Facade::class,
+];
+```
+  
+## Usage
+ 
+The package is based on Laravel Collections, so you basically have access to all methods in Collections, like 
+
+```php
+$all = Countries::all();
+```
+     
+This filter
+
+```php
+Countries::where('name.common', 'Brazil')
+```
+
+Will find Brazil by its common name, which is a 
+
+```
+#items: array:22 [▼
+  "name" => array:3 [▼
+    "common" => "Brazil"
+    "official" => "Federative Republic of Brazil"
+    "native" => array:1 [▼
+      "por" => array:2 [▼
+        "official" => "República Federativa do Brasil"
+        "common" => "Brasil"
+      ]
+    ]
+  ]
+```
+        
+And, you can go deepeer
+         
+```php
+Countries::where('name.native.por.common', 'Brasil')
+```
+     
+Or search by the country top level domain
+     
+```php
+Countries::where('tld.0', '.ch')
+```
+     
+To get
+
+```
+"name" => array:3 [▼
+  "common" => "Switzerland"
+  "official" => "Swiss Confederation"
+  "native" => array:4 [▶]
+]
+"tld" => array:1 [▼
+  0 => ".ch"
+]
+```
+    
+And use things like pluck
+
+```php
+Countries::where('cca3', 'USA')->first()->states->pluck('name', 'postal')
+```
+
+To get
+
+```php
+"MA" => "Massachusetts"
+"MN" => "Minnesota"
+"MT" => "Montana"
+"ND" => "North Dakota"
+"HI" => "Hawaii"
+"ID" => "Idaho"
+"WA" => "Washington"
+"AZ" => "Arizona"
+"CA" => "California"
+"CO" => "Colorado"
+"NV" => "Nevada"
+"NM" => "New Mexico"
+"OR" => "Oregon"
+"UT" => "Utah"
+"WY" => "Wyoming"
+"AR" => "Arkansas"
+"IA" => "Iowa"
+"KS" => "Kansas"
+"MO" => "Missouri"
+"NE" => "Nebraska"
+"OK" => "Oklahoma"
+"SD" => "South Dakota"
+"LA" => "Louisiana"
+"TX" => "Texas"
+"CT" => "Connecticut"
+"NH" => "New Hampshire"
+"RI" => "Rhode Island"
+"VT" => "Vermont"
+"AL" => "Alabama"
+"FL" => "Florida"
+"GA" => "Georgia"
+"MS" => "Mississippi"
+"SC" => "South Carolina"
+"IL" => "Illinois"
+"IN" => "Indiana"
+"KY" => "Kentucky"
+"NC" => "North Carolina"
+"OH" => "Ohio"
+"TN" => "Tennessee"
+"VA" => "Virginia"
+"WI" => "Wisconsin"
+"WV" => "West Virginia"
+"DE" => "Delaware"
+"DC" => "District of Columbia"
+"MD" => "Maryland"
+"NJ" => "New Jersey"
+"NY" => "New York"
+"PA" => "Pennsylvania"
+"ME" => "Maine"
+"MI" => "Michigan"
+"AK" => "Alaska"
+```
+          
+The package uses a modified Collection which allows you to access properties and methods as objects:
+    
+```php
+Countries::where('cca3', 'FRA')
+         ->first()
+         ->borders
+         ->first()
+         ->name
+         ->official
+```
+
+    
+Should give
+    
+```
+Principality of Andorra
+```
+         
+Borders hydration is disabled by default, but you can have your borders hydrated easily by calling the hydrate method:
+
+```php
+Countries::where('name.common', 'United Kingdom')
+         ->hydrate('borders')
+         ->first()
+         ->borders
+         ->reverse()
+         ->first()
+         ->name
+         ->common
+```
+
+Should return 
+
+```
+Ireland
+```
+
+## Publishing assets
+
+You can publish configuration and views using:
+```
+php artisan vendor:publish --provider=PragmaRX\Countries\ServiceProvider --tag=config
+php artisan vendor:publish --provider=PragmaRX\Countries\ServiceProvider --tag=views
+```
+
+## Data
+
+This package uses some other open source packages and, until we don't build a better documentation, you can find some more info about data on [mledoze/countries](https://github.com/mledoze/countries/blob/master/README.md) and how to use it on this fantastic [Laravel News article](https://laravel-news.com/countries-and-currencies).
+
+## Cache
+
+Since this data is not supposed to change, calls are automatically cached.
+If you want to change this behaviour, you can edit `config/countries.php` file once you published it.
+
+## Sample files
+
+- [sample-partial.json](src/data/sample-partial.json): example of a country with no borders hydrated.
+- [sample-full.json](src/data/sample-full.json): example of a fully hydrated country.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ This package uses some other open source packages and, until we don't build a be
 ## Cache
 
 Since this data is not supposed to change, calls are automatically cached.
-If you want to change this behaviour, you can edit `config/countries.php` file once you published it.
+If you want to change this behaviour, you can edit `config/countries.php` file once it's published.
 
 ## Sample files
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -23,11 +23,11 @@ class ServiceProvider extends IlluminateServiceProvider
     {
         $this->publishes([
             __DIR__.'/config/config.php' => config_path('countries.php'),
-        ]);
+        ], 'config');
 
         $this->publishes([
             __DIR__.'/views/' => resource_path('views/vendor/pragmarx/countries/'),
-        ]);
+        ], 'views');
     }
 
     /**


### PR DESCRIPTION
- Added tags for published assets to easily choose which files to copy.
- Referenced previously mentioned change in README.
- Moved **Requirements** and **Installation** above **Usage**. You need to install it in order to use it.
- Removed some leading whitespaces.
- Added some syntax highlighting.

The `vendor:publish` command fails on `--tag=views` because it cannot find the `src/views` path, but I figured you're planning to add that, so I didn't remove the reference.