### PR TITLE
Static Code Analysis: minor code tweaks

### DIFF
--- a/src/package/Countries.php
+++ b/src/package/Countries.php
@@ -45,7 +45,7 @@ class Countries
      */
     public function __call($name, array $arguments = [])
     {
-        return call_user_func_array([$this->countriesService, $name], $arguments);
+        return \call_user_func_array([$this->countriesService, $name], $arguments);
     }
 
     /**
@@ -57,6 +57,6 @@ class Countries
      */
     public static function __callStatic($name, array $arguments = [])
     {
-        return call_user_func_array([new static(), $name], $arguments);
+        return \call_user_func_array([new static(), $name], $arguments);
     }
 }

--- a/src/package/Data/Repository.php
+++ b/src/package/Data/Repository.php
@@ -84,7 +84,7 @@ class Repository
      */
     public function __call($name, array $arguments = [])
     {
-        return call_user_func_array([$this->all(), $name], $arguments);
+        return \call_user_func_array([$this->all(), $name], $arguments);
     }
 
     /**
@@ -100,7 +100,7 @@ class Repository
             return $value;
         }
 
-        $result = call_user_func_array([$this, $name], $arguments);
+        $result = \call_user_func_array([$this, $name], $arguments);
 
         if ($this->config->get('hydrate.before')) {
             $result = $this->hydrator->hydrate($result);

--- a/src/package/Services/Cache/Managers/Nette.php
+++ b/src/package/Services/Cache/Managers/Nette.php
@@ -38,11 +38,8 @@ class Nette implements CacheInterface
      */
     public function __construct($config = null, $path = null)
     {
-        $this->config = is_null($config) ? new Config() : $config;
-
-        $this->cache = new NetteCache(
-            $this->getStorage($path = null)
-        );
+        $this->config = \is_null($config) ? new Config() : $config;
+        $this->cache = new NetteCache($this->getStorage());
     }
 
     /**
@@ -62,7 +59,7 @@ class Nette implements CacheInterface
      */
     public function getCacheDir()
     {
-        if (is_null($this->dir)) {
+        if (\is_null($this->dir)) {
             $this->dir = $this->config->cache->directory ?: sys_get_temp_dir().'/__PRAGMARX_COUNTRIES__/cache';
 
             if (! file_exists($this->dir)) {
@@ -82,7 +79,7 @@ class Nette implements CacheInterface
     public function getStorage($path = null)
     {
         return new FileStorage(
-            is_null($path)
+            \is_null($path)
                 ? $this->getCacheDir()
                 : $path
         );
@@ -108,9 +105,7 @@ class Nette implements CacheInterface
      */
     protected function makeExpiration($ttl)
     {
-        $expiration = ($ttl ?: $this->config->get('cache.duration')).' minutes';
-
-        return $expiration;
+        return ($ttl ?: $this->config->get('cache.duration')).' minutes';
     }
 
     /**
@@ -198,7 +193,7 @@ class Nette implements CacheInterface
      */
     public function has($key)
     {
-        return ! is_null($this->get($key));
+        return ! \is_null($this->get($key));
     }
 
     /**
@@ -213,7 +208,7 @@ class Nette implements CacheInterface
     {
         $value = $this->get($key);
 
-        if (! is_null($value)) {
+        if (! \is_null($value)) {
             return $value;
         }
 

--- a/src/package/Services/Cache/Service.php
+++ b/src/package/Services/Cache/Service.php
@@ -51,7 +51,7 @@ class Service implements CacheInterface
      */
     public function instantiateConfig($config)
     {
-        return is_null($config) ? new Config() : $config;
+        return \is_null($config) ? new Config() : $config;
     }
 
     /**
@@ -64,7 +64,7 @@ class Service implements CacheInterface
      */
     public function instantiateManager($config, $manager, $path)
     {
-        return is_null($manager)
+        return \is_null($manager)
             ? new NetteManager($config, $path)
             : $manager;
     }
@@ -101,7 +101,7 @@ class Service implements CacheInterface
      */
     public function makeKey()
     {
-        $arguments = func_get_args();
+        $arguments = \func_get_args();
 
         if (empty($arguments)) {
             throw new Exception('Empty key');
@@ -202,7 +202,7 @@ class Service implements CacheInterface
      */
     public function remember($key, $minutes, Closure $callback)
     {
-        if (! is_null($value = $this->manager->get($key))) {
+        if (! \is_null($value = $this->manager->get($key))) {
             return $value;
         }
 

--- a/src/package/Services/Config.php
+++ b/src/package/Services/Config.php
@@ -42,7 +42,7 @@ class Config
      */
     protected function initialize($config = [])
     {
-        if (is_object($config)) {
+        if (\is_object($config)) {
             $this->config = $config;
 
             $this->prefix = 'countries.';
@@ -83,6 +83,6 @@ class Config
      */
     public function __call($name, $arguments)
     {
-        return call_user_func_array([$this->config, $name], $arguments);
+        return \call_user_func_array([$this->config, $name], $arguments);
     }
 }

--- a/src/package/Services/Countries.php
+++ b/src/package/Services/Countries.php
@@ -178,8 +178,8 @@ class Countries extends Base
      */
     protected function instantiateCache(Cache $cache = null)
     {
-        if (is_null($this->cache) || ! is_null($cache)) {
-            $this->cache = ! is_null($cache)
+        if (\is_null($this->cache) || ! \is_null($cache)) {
+            $this->cache = ! \is_null($cache)
                 ? $cache
                 : new Cache($this->config);
         }
@@ -195,8 +195,8 @@ class Countries extends Base
      */
     protected function instantiateConfig($config = null)
     {
-        if (is_null($this->config) || ! is_null($config)) {
-            $this->config = ! is_null($config)
+        if (\is_null($this->config) || ! \is_null($config)) {
+            $this->config = ! \is_null($config)
                 ? $config
                 : new Config($this->helper);
         }
@@ -210,8 +210,8 @@ class Countries extends Base
      */
     protected function instantiateHelper(Helper $helper = null)
     {
-        $this->helper = is_null($helper)
-            ? (is_null($this->helper)
+        $this->helper = \is_null($helper)
+            ? (\is_null($this->helper)
                 ? $this->helper = new Helper($this->instantiateConfig())
                 : $this->helper)
             : $helper;
@@ -227,8 +227,8 @@ class Countries extends Base
      */
     protected function instantiateHydrator(Hydrator $hydrator = null)
     {
-        if (is_null($this->hydrator) || ! is_null($hydrator)) {
-            $this->hydrator = ! is_null($hydrator)
+        if (\is_null($this->hydrator) || ! \is_null($hydrator)) {
+            $this->hydrator = ! \is_null($hydrator)
                 ? $hydrator
                 : new Hydrator($this->config);
         }
@@ -242,7 +242,7 @@ class Countries extends Base
      */
     protected function instantiateRepository($repository)
     {
-        if (is_null($repository)) {
+        if (\is_null($repository)) {
             $repository = new Repository(
                 $this->instantiateCache(),
                 $this->instantiateHydrator(),
@@ -259,7 +259,7 @@ class Countries extends Base
      */
     protected function instantiateUpdater()
     {
-        if (is_null($this->updater)) {
+        if (\is_null($this->updater)) {
             $this->updater = new Updater($this->config, $this->helper);
         }
 

--- a/src/package/Services/Helper.php
+++ b/src/package/Services/Helper.php
@@ -54,7 +54,7 @@ class Helper
 
         $decoded = json5_decode($this->loadFile($file), true);
 
-        if (is_null($decoded)) {
+        if (\is_null($decoded)) {
             throw new Exception("Error decoding json file: $file");
         }
 
@@ -70,7 +70,7 @@ class Helper
     public function loadJsonFiles($dir)
     {
         return coollect(glob("$dir/*.json*"))->mapWithKeys(function ($file) {
-            $key = str_replace('.json', '', str_replace('.json5', '', basename($file)));
+            $key = str_replace(array('.json5', '.json'), '', basename($file));
 
             return [$key => $this->loadJson($file)];
         });

--- a/src/package/Services/Helper.php
+++ b/src/package/Services/Helper.php
@@ -70,7 +70,7 @@ class Helper
     public function loadJsonFiles($dir)
     {
         return coollect(glob("$dir/*.json*"))->mapWithKeys(function ($file) {
-            $key = str_replace(array('.json5', '.json'), '', basename($file));
+            $key = str_replace(['.json5', '.json'], '', basename($file));
 
             return [$key => $this->loadJson($file)];
         });

--- a/src/package/Services/Hydrator.php
+++ b/src/package/Services/Hydrator.php
@@ -132,7 +132,7 @@ class Hydrator
      */
     private function isCountry($element)
     {
-        return ($element instanceof Coollection || is_array($element)) && isset($element['cca3']);
+        return ($element instanceof Coollection || \is_array($element)) && isset($element['cca3']);
     }
 
     /**
@@ -143,7 +143,7 @@ class Hydrator
      */
     private function isCurrenciesArray($data)
     {
-        return is_array($data) && isset($data['ISO4217Code']);
+        return \is_array($data) && isset($data['ISO4217Code']);
     }
 
     /**
@@ -274,7 +274,7 @@ class Hydrator
     {
         $elements = ($elements ?: $this->config->get('hydrate.elements'));
 
-        if (is_string($elements) || is_numeric($elements)) {
+        if (\is_string($elements) || is_numeric($elements)) {
             return [$elements => true];
         }
 

--- a/src/package/Support/Base.php
+++ b/src/package/Support/Base.php
@@ -6,8 +6,8 @@ class Base
 {
     public function defineConstants()
     {
-        if (! defined('__COUNTRIES_DIR__')) {
-            define(
+        if (! \defined('__COUNTRIES_DIR__')) {
+            \define(
                 '__COUNTRIES_DIR__',
                 realpath(
                     __DIR__.$this->helper->toDir('/../../../')

--- a/src/package/Support/Collection.php
+++ b/src/package/Support/Collection.php
@@ -17,11 +17,13 @@ class Collection extends Coollection
      */
     public function __call($name, $arguments)
     {
-        if (starts_with($name, 'where') && $name !== 'where') {
+        if ($name !== 'where' && starts_with($name, 'where')) {
             $name = strtolower(preg_replace('/([A-Z])/', '.$1', lcfirst(substr($name, 5))));
-            if (count($arguments) == 2) {
+            if (\count($arguments) === 2) {
                 return $this->where($name, $arguments[0], $arguments[1]);
-            } elseif (count($arguments) == 1) {
+            }
+
+            if (\count($arguments) === 1) {
                 return $this->where($name, $arguments[0]);
             }
         }
@@ -50,7 +52,7 @@ class Collection extends Coollection
      */
     public function where($key, $operator, $value = null)
     {
-        if (func_num_args() == 2) {
+        if (\func_num_args() === 2) {
             $value = $operator;
 
             $operator = '=';
@@ -113,7 +115,7 @@ class Collection extends Coollection
                 $attributeValue = null;
             }
 
-            return is_null($attributeValue)
+            return \is_null($attributeValue)
                 ? null
                 : $finderClosure($find, $attributeValue, $data);
         });
@@ -147,7 +149,7 @@ class Collection extends Coollection
     private function _whereAttribute(string $arrayName, $value)
     {
         $finderClosure = function ($value, $attributeValue) {
-            return in_array($value, $attributeValue->toArray());
+            return \in_array($value, $attributeValue->toArray());
         };
 
         return $this->hydrateDefaultElements(


### PR DESCRIPTION
This PR applies a set of micro-optimizations and control flow tweaks:

- enabling opcode caching (`\` prefixes for certain functions, improves performance in general)
- merging `str_replace` calls (a micro-optimization)
- enabling strict comparison where it makes sense
- a pair of if-construct tweaks

PS: many thanks for the extension!

