### PR TITLE
updated dependencies for laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
 
     "require": {
-        "php": ">=7.0",
+        "php": "^7.2.5",
         "pragmarx/coollection": ">=0.5",
         "psr/simple-cache": "^1.0",
         "nette/caching": "^2.5",
@@ -35,8 +35,8 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "~6.0|~7.0|~8.0",
-        "squizlabs/php_codesniffer": "^2.3",
+        "phpunit/phpunit": "^8.5",
+        "squizlabs/php_codesniffer": "^3.4",
         "gasparesganga/php-shapefile": "^2.4"
     },
 


### PR DESCRIPTION
when required from composer the package gives error that var-dumper is outdated. 
changed var-dumper in other packages for countries.
changed the php version required to 7.2.5 as this is what laravel 7 uses now.
phpunit and codesniffer also require higher version.
i havent tested this as im new to github and dont know how to test this as it is your project.
hope it is to any help.