### PR TITLE
Update Mauritania currency to reflect change from MRO to MRU

### DIFF
--- a/src/data/currencies/default/mru.json
+++ b/src/data/currencies/default/mru.json
@@ -23,11 +23,12 @@
         ]
     },
     "data_sources": [
-        "world-currencies"
+        "world-currencies",
+        "ISO-4217"
     ],
     "iso": {
-        "code": "MRO",
-        "number": "478"
+        "code": "MRU",
+        "number": "929"
     },
     "name": "Mauritanian Ouguiya",
     "record_type": "currency",


### PR DESCRIPTION
The ISO Currency Codes for the ouguiya were amended to MRU / 929 and the existing codes of MRO / 478 were retired as per ISO 4217 Amendment Number 165 dated 14 Dec 2017.