### PR TITLE
Update dependencies for Laravel 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 php:
 #  - 7.0
-  - 7.1
+#  - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
 
     "require": {
-        "php": ">=7.0",
+        "php": "^7.2.5",
         "pragmarx/coollection": ">=0.5",
         "psr/simple-cache": "^1.0",
         "nette/caching": "^2.5",
@@ -35,8 +35,8 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "~6.0|~7.0|~8.0",
-        "squizlabs/php_codesniffer": "^2.3",
+        "phpunit/phpunit": "^8.5",
+        "squizlabs/php_codesniffer": "^3.4",
         "gasparesganga/php-shapefile": "^2.4"
     },
 


### PR DESCRIPTION
Updated dependencies for Laravel 7.

## Description
Removed PHP 7.1 from travis.yml as Laravel 7 uses PHP 7.2.5
Updated dependencies to newer versions as Laravel 7 uses newer versions of `phpunit`, `carbon`, etc.