### PR TITLE
Fix flag-icon

### DIFF
--- a/src/package/Data/Repository.php
+++ b/src/package/Data/Repository.php
@@ -232,8 +232,8 @@ class Repository
             'sprite' => '<span class="flag flag-'.($cca3 = strtolower($country['cca3'])).'"></span>',
 
             // https://github.com/lipis/flag-icon-css
-            'flag-icon' => '<span class="flag-icon flag-icon-'.($iso_a2 = strtolower($country['iso_a2'])).'"></span>',
-            'flag-icon-squared' => '<span class="flag-icon flag-icon-'.$iso_a2.' flag-icon-squared"></span>',
+            'flag-icon' => '<span class="flag-icon flag-icon-'.($iso_3166_1_alpha2 = strtolower($country['iso_3166_1_alpha2'])).'"></span>',
+            'flag-icon-squared' => '<span class="flag-icon flag-icon-'.$iso_3166_1_alpha2.' flag-icon-squared"></span>',
 
             // https://github.com/lafeber/world-flags-sprite
             'world-flags-sprite' => '<span class="flag '.$cca3.'"></span>',


### PR DESCRIPTION
Currently the flag-icon property is broken because we are using the wrong property to fill the icon name. 

For example, [Norway](https://github.com/antonioribeiro/countries/blob/v0.7.1/src/data/countries/default/nor.json#L149) it's `iso_a2` property is set to `-99`.

You [need to use the ISO 3166-1-alpha-2 code](https://github.com/lipis/flag-icon-css#usage) of a country to get the correct country code.