### PR TITLE
Fix to use currencies instead of currency in whereISO4217()

### DIFF
--- a/src/package/Support/Collection.php
+++ b/src/package/Support/Collection.php
@@ -96,7 +96,7 @@ class Collection extends Coollection
      */
     public function whereISO4217($value)
     {
-        return $this->_whereAttribute('currency', $value);
+        return $this->_whereAttribute('currencies', $value);
     }
 
     /**

--- a/tests/CountriesTest.php
+++ b/tests/CountriesTest.php
@@ -191,6 +191,16 @@ class CountriesTest extends PHPUnitTestCase
         );
     }
 
+    public function testCountryWhereISO4217()
+    {
+        $this->assertEquals(Countries::currencies()->count(), 153);
+
+        $this->assertEquals(
+            'POL',
+            Countries::whereISO4217('PLN')->first()->cca3,
+        );
+    }
+
     public function testTimezones()
     {
         $this->assertEquals(


### PR DESCRIPTION
Probably related to #155 