### PR TITLE
FIX: typo in the state District of Colombia

### DIFF
--- a/src/data/states/default/usa.json
+++ b/src/data/states/default/usa.json
@@ -715,7 +715,7 @@
     },
     "DC": {
         "alt_names": [
-            "District of Columbia"
+            "District of Colombia"
         ],
         "cca2": "US",
         "cca3": "USA",


### PR DESCRIPTION
### Thank you for making this package!

I found a small typo that I had to hardcode in the project I'm working on, so I thought I make a PR for it.
Please let me know if I need to update other files as well.

## Bug

The state "District of **Colombia**" was misspelled like this "District of **Columbia**".