### PR TITLE
Remove redundant `countries` prefix on config keys

### DIFF
--- a/src/package/Services/Cache/Managers/Nette.php
+++ b/src/package/Services/Cache/Managers/Nette.php
@@ -49,7 +49,7 @@ class Nette implements CacheInterface
      */
     protected function enabled()
     {
-        return $this->config->get('countries.cache.enabled');
+        return $this->config->get('cache.enabled');
     }
 
     /**

--- a/src/package/Services/Cache/Service.php
+++ b/src/package/Services/Cache/Service.php
@@ -76,7 +76,7 @@ class Service implements CacheInterface
      */
     protected function enabled()
     {
-        return $this->config->get('countries.cache.enabled');
+        return $this->config->get('cache.enabled');
     }
 
     /**


### PR DESCRIPTION
Using https://github.com/antonioribeiro/countries-laravel, there is no way to enable or disable caching by overwriting the `countries.php` config. I found that this is due to redundant `countries.` prefixes in the Cache Service and Nette classes which lead to effectively reading from `countries.countries.cache.enabled`, thus ignoring any settings for cache.enabled.

This is reproducible by publishing the config and changing any of the cache settings, for example the temp directory. All of the settings will be ignored, because the request to `countries.countries.cache.enabled` will return null, which is cast to false when returned from the Cache's `enabled()` method.

This PR will remove the redundant `countries` prefixes and will presumably also fix https://github.com/antonioribeiro/countries-laravel/issues/17.