### PR TITLE
Return psr/simple-cache v1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=7.0",
         "pragmarx/coollection": ">=0.8",
-        "psr/simple-cache": "^2.0",
+        "psr/simple-cache": "^1.0|^2.0",
         "nette/caching": "^2.5|^3.0",
         "colinodell/json5": "^1.0|^2.0"
     },


### PR DESCRIPTION
Interface for psr/simple-cache has no breaking changes (with current implementation in mind) between v1 and v2: https://github.com/php-fig/simple-cache/compare/1.0.1...2.0.0
Most changes in v2 are related to strong typing and the current implementation of PragmaRX\Countries\Package\Services\Cache\Service will work with both versions of psr/simple-cache.
Such versioning will allow to use this package with Laravel 8, which requires "psr/simple-cache": "^1.0"

Actually, Laravel 9 requirements are "psr/simple-cache": "^1.0|^2.0|^3.0". And v3 just adds return types for methods: https://github.com/php-fig/simple-cache/compare/2.0.0...3.0.0
So, if you will NOT add types for methods parameters and will add return types, then such implementation of cache service will work with all current versions of psr/simple-cache