### PR TITLE
Update pragmarx/coollection dependency to make it compatible with Laravel9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /src/data/third-party/
 composer.phar
 composer.lock
+*.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-#  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
   - 7.4
+  - 8.0
+  - 8.1
 # - nightly
 
 env:
@@ -23,7 +21,7 @@ cache:
 
 ## Disable Xdebug on all PHP versions except those ones below
 before_script:
-  - '[[ "$TRAVIS_PHP_VERSION" == "7.3" || "$TRAVIS_PHP_VERSION" == "nightly" || "$TRAVIS_PHP_VERSION" == "7.4snapshot" ]] || phpenv config-rm xdebug.ini'
+  - '[[ "$TRAVIS_PHP_VERSION" == "8.0" || "$TRAVIS_PHP_VERSION" == "nightly" ]] || phpenv config-rm xdebug.ini'
   - travis_retry composer self-update
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
 # - '[[ "$TRAVIS_PHP_VERSION" == "7.4snapshot" ]] && composer require nette/finder:"dev-master" --no-interaction --prefer-dist || echo done'
@@ -33,7 +31,7 @@ script:
 
 after_script:
   - |
-    if [[ "$TRAVIS_PHP_VERSION" == '7.2' ]]; then
+    if [[ "$TRAVIS_PHP_VERSION" == '8.0' ]]; then
       wget https://scrutinizer-ci.com/ocular.phar
       php ocular.phar code-coverage:upload --format=php-clover coverage.clover
     fi

--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,28 @@
         }
     ],
 
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/asbiin/coollection"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/asbiin/ia-collection"
+        }
+    ],
     "require": {
         "php": ">=7.0",
-        "pragmarx/coollection": ">=0.8",
+        "pragmarx/coollection": "dev-update-ia-collection",
+        "pragmarx/ia-collection": "dev-update-var-dumper",
         "psr/simple-cache": "^1.0|^2.0",
         "nette/caching": "^2.5|^3.0",
         "colinodell/json5": "^1.0|^2.0"
     },
 
     "require-dev": {
-        "phpunit/phpunit": "~6.0|~7.0|~8.0",
-        "squizlabs/php_codesniffer": "^2.3",
+        "phpunit/phpunit": "~6.0|~7.0|~8.0|~9.0",
+        "squizlabs/php_codesniffer": "^2.3|^3.6",
         "gasparesganga/php-shapefile": "^3.4"
     },
 


### PR DESCRIPTION
Update `pragmarx/coollection` dependency.
Also remove `composer.lock` and update travis config file.

## Motivation and context

Laravel 9.x requires `symfony/var-dumper` ^6.0  and `voku/portable-ascii` ^2.0.
This is part of some updates on multiple `pragmarx` packages which aren't compatible with Laravel9 yet, this helps fixing that.

See
- https://github.com/antonioribeiro/coollection/pull/14
- https://github.com/antonioribeiro/ia-str/pull/5
- https://github.com/antonioribeiro/ia-collection/pull/11
- https://github.com/antonioribeiro/ia-arr/pull/4
