### PR TITLE
Update cache implementations to be compatible with php8 + psr/simple-cache 3.0

### DIFF
--- a/src/package/Data/Repository.php
+++ b/src/package/Data/Repository.php
@@ -107,7 +107,9 @@ class Repository
             $result = $this->hydrator->hydrate($result);
         }
 
-        return $this->cache->set($cacheKey, $result, $this->config->get('cache.duration'));
+        $this->cache->set($cacheKey, $result, $this->config->get('cache.duration'));
+
+        return $result;
     }
 
     /**

--- a/src/package/Services/Cache/Managers/Nette.php
+++ b/src/package/Services/Cache/Managers/Nette.php
@@ -93,11 +93,13 @@ class Nette implements CacheInterface
      * @param  null  $default
      * @return mixed
      */
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         if ($this->enabled()) {
             return $this->cache->load($key, $default);
         }
+
+        return null;
     }
 
     /**
@@ -117,13 +119,13 @@ class Nette implements CacheInterface
      * @param  null  $ttl
      * @return bool
      */
-    public function set($key, $value, $ttl = null)
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
     {
         if ($this->enabled()) {
             return $this->cache->save($key, $value, [NetteCache::EXPIRE => $this->makeExpiration($ttl)]);
         }
 
-        return $value;
+        return false;
     }
 
     /**
@@ -132,17 +134,19 @@ class Nette implements CacheInterface
      * @param  string  $key
      * @return bool
      */
-    public function delete($key)
+    public function delete(string $key): bool
     {
         $this->cache->remove($key);
+        return true;
     }
 
     /**
      * Wipe clean the entire cache's keys.
      */
-    public function clear()
+    public function clear(): bool
     {
         $this->cache->clean([NetteCache::ALL => true]);
+        return true;
     }
 
     /**
@@ -152,7 +156,7 @@ class Nette implements CacheInterface
      * @param  null  $default
      * @return array
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         return coollect($keys)->map(function ($key) {
             return $this->get($key);
@@ -166,24 +170,26 @@ class Nette implements CacheInterface
      * @param  null  $ttl
      * @return bool
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
     {
-        return coollect($values)->map(function ($value, $key) use ($ttl) {
+        coollect($values)->map(function ($value, $key) use ($ttl) {
             return $this->set($key, $value, $ttl);
         });
+        return true;
     }
 
     /**
      * Deletes multiple cache items in a single operation.
      *
      * @param $keys
-     * @return bool|void
+     * @return bool
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple(iterable $keys): bool
     {
         coollect($keys)->map(function ($key) {
-            $this->forget($key);
+            $this->delete($key);
         });
+        return true;
     }
 
     /**
@@ -192,7 +198,7 @@ class Nette implements CacheInterface
      * @param  string  $key
      * @return bool
      */
-    public function has($key)
+    public function has(string $key): bool
     {
         return ! \is_null($this->get($key));
     }

--- a/src/package/Services/Cache/Service.php
+++ b/src/package/Services/Cache/Service.php
@@ -12,7 +12,7 @@ class Service implements CacheInterface
     /**
      * Cache.
      *
-     * @var object
+     * @var NetteManager
      */
     protected $manager;
 
@@ -87,11 +87,13 @@ class Service implements CacheInterface
      * @param  null  $default
      * @return mixed|null
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         if ($this->enabled()) {
             return $this->manager->get($key, $default);
         }
+
+        return null;
     }
 
     /**
@@ -106,7 +108,7 @@ class Service implements CacheInterface
         $arguments = \func_get_args();
 
         if (empty($arguments)) {
-            throw new Exception('Empty key');
+            throw new \Exception('Empty key');
         }
 
         return base64_encode(serialize($arguments));
@@ -120,13 +122,13 @@ class Service implements CacheInterface
      * @param  null  $ttl
      * @return bool
      */
-    public function set($key, $value, $ttl = null)
+    public function set($key, $value, $ttl = null): bool
     {
         if ($this->enabled()) {
             return $this->manager->set($key, $value, $ttl);
         }
 
-        return $value;
+        return false;
     }
 
     /**
@@ -135,17 +137,17 @@ class Service implements CacheInterface
      * @param  string  $key
      * @return bool
      */
-    public function delete($key)
+    public function delete($key): bool
     {
-        $this->manager->delete($key);
+        return $this->manager->delete($key);
     }
 
     /**
      * Wipe clean the entire cache's keys.
      */
-    public function clear()
+    public function clear(): bool
     {
-        $this->manager->clear();
+        return $this->manager->clear();
     }
 
     /**
@@ -155,7 +157,7 @@ class Service implements CacheInterface
      * @param  null  $default
      * @return array
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple($keys, $default = null): iterable
     {
         return $this->manager->getMultiple($keys, $default);
     }
@@ -167,9 +169,9 @@ class Service implements CacheInterface
      * @param  null  $ttl
      * @return bool
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple($values, $ttl = null): bool
     {
-        return $this->manager->setMultiple($keys, $ttl);
+        return $this->manager->setMultiple($values, $ttl);
     }
 
     /**
@@ -178,9 +180,9 @@ class Service implements CacheInterface
      * @param $keys
      * @return bool|void
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple($keys): bool
     {
-        $this->manager->deleteMultiple($keys);
+        return $this->manager->deleteMultiple($keys);
     }
 
     /**
@@ -189,7 +191,7 @@ class Service implements CacheInterface
      * @param  string  $key
      * @return bool
      */
-    public function has($key)
+    public function has($key): bool
     {
         return $this->manager->has($key);
     }


### PR DESCRIPTION
To fix: https://github.com/upmind/provision-provider-domain-names/issues/107